### PR TITLE
Add tournament description, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `pip install -r requirements.txt`
 
-`python manage.py syncdb`
+`python manage.py makemigrations`
 
 `python manage.py migrate`
 
@@ -27,3 +27,15 @@
 #### build automaticaly on file change
 
 `grunt watch`
+
+#### run server
+python manage.py runserver
+
+## Windows troubles
+Add this into settings.py during development if you encounter encoding errors
+
+```
+import sys
+reload(sys)
+sys.setdefaultencoding('UTF8')
+```

--- a/ufobalapp/models.py
+++ b/ufobalapp/models.py
@@ -244,6 +244,7 @@ class Tournament(models.Model):
     name = models.CharField('Název/místo', max_length=50)
     halftime_length = models.IntegerField('Délka poločasu', default=8)
     field_count = models.IntegerField('Počet hřišť', default=2)
+    description = models.TextField("Popis", null=True, blank=True)
 
     def to_json(self, teams=True, **kwargs):
         data = {
@@ -258,6 +259,7 @@ class Tournament(models.Model):
             "halftime_length": self.halftime_length,
             "field_count": self.field_count,
             "year": self.date.year,
+            "description": self.description
         }
 
         if teams:

--- a/ufobalapp/static/ufobalapp/js/app.js
+++ b/ufobalapp/static/ufobalapp/js/app.js
@@ -117,13 +117,16 @@ app.config(['$routeProvider', '$locationProvider', function ($routeProvider, $lo
     }]);
 
 
-app.controller("home", ["$scope", "dataService", function ($scope, dataService) {
+app.controller("home", ["$scope", "dataService", "$sce", function ($scope, dataService, $sce) {
     dataService.getStats().then(function (stats) {
        $scope.stats = stats;
     });
     dataService.getLiveTournament().then(function (tournament) {
        $scope.liveTournament = tournament;
     });
+    $scope.to_trusted = function(html_code) {
+        return $sce.trustAsHtml(html_code);
+    };
 }]);
 
 app.controller("hall_of_fame", ["$scope", "dataService", function ($scope, dataService) {

--- a/ufobalapp/static/ufobalapp/ng-parts/home.html
+++ b/ufobalapp/static/ufobalapp/ng-parts/home.html
@@ -25,6 +25,7 @@
         <h3><a href="/turnaj">{{ liveTournament.full_name }}</a></h3>
         <strong>datum:</strong> {{ liveTournament.date | date : "d. M. yyyy"}}<br>
         <div ng-show="liveTournament.registration_open"><a href="/turnaj/prihlasovani">přihlásit se na turnaj</a> - do {{ liveTournament.registration_to | date : "d. M. yyyy"}}</div>
+        <span ng-show="liveTournament.description" ng-bind-html="to_trusted(liveTournament.description)"></span>
     </div>
 
     <hr>


### PR DESCRIPTION
Based on this https://www.facebook.com/ufobal/posts/10158682885627318?comment_id=10158682892907318
with this change, we can render custom description (even with html link) directly under the live tournament on main page